### PR TITLE
Update dataset_generator.py

### DIFF
--- a/dataset_generator.py
+++ b/dataset_generator.py
@@ -289,7 +289,7 @@ def create_image_anno(objects, distractor_objects, img_file, anno_file, bg_file,
            mask = Image.open(mask_file)
            mask = mask.crop((xmin, ymin, xmax, ymax))
            if INVERTED_MASK:
-               mask = Image.fromarray(255-PIL2array1C(mask))
+               mask = Image.fromarray(255-PIL2array1C(mask)).convert('1')
            o_w, o_h = orig_w, orig_h
            if scale_augment:
                 while True:


### PR DESCRIPTION
Loading a map from a pbm file uses Pillow's '1' mode. The line `Image.fromarray(255-PIL2array1C(mask))` gives you an image in Pillow's 'L' mode. See [here](https://pillow.readthedocs.io/en/stable/handbook/concepts.html#concept-modes) for details. 

The two modes behave differently when you call `mask.resize((o_w, o_h), Image.ANTIALIAS)`. Consider the following code:

```
from PIL import Image
import numpy as np

NEW_SIZE = 100, 100

def binary_mask(mask):
    return np.array(np.where(np.array(mask) == 0, 0, 255), np.uint8)

def PIL2array1C(img):
    '''Converts a PIL image to NumPy Array
    Args:
        img(PIL Image): Input PIL image
    Returns:
        NumPy Array: Converted image
    '''
    return np.array(img.getdata(),
                    np.uint8).reshape(img.size[1], img.size[0])

mask = Image.open('dot.pbm')
mask_l_mode = Image.fromarray(255-PIL2array1C(mask))
mask_one_mode = mask_l_mode.convert('1')

mask_l_mode = mask_l_mode.resize(NEW_SIZE, Image.LANCZOS)
print(np.unique(np.array(mask_l_mode)))
Image.fromarray(binary_mask(mask_l_mode)).show()

mask_one_mode = mask_one_mode.resize(NEW_SIZE, Image.LANCZOS)
print(np.unique(np.array(mask_one_mode)))
Image.fromarray(binary_mask(mask_one_mode)).show()
```

I ran it with the pbm file in [this archive](https://github.com/debidatta/syndata-generation/files/5413426/dot.zip).

It printed:
```
[  0   1   2   3   4   5   6   7   9  10  11  12  13  14  15  16  18  19
  20  21  22  23  60  61  62  63  68  69  70  71  72  73  74  75  76  77
  78 111 112 118 119 121 123 124 125 127 128 129 130 131 132 133 134 135
 136 142 177 178 179 180 182 183 184 185 186 192 193 194 232 233 234 235
 236 237 238 239 240 241 242 243 244 245 246 248 249 250 251 252 253 254
 255]
[False  True]
```

The first time `show()` is called, it results in this image: 
![dot1](https://user-images.githubusercontent.com/2359046/96676003-4fa24e80-133a-11eb-830a-a90ed623d6e0.png)

The second time `show()` is called, it results in this image:
![dot2](https://user-images.githubusercontent.com/2359046/96676120-9abc6180-133a-11eb-8d86-5ea21b7aab58.png)

This pull request converts the inverted mask to 1 mode, to match the mode that masks are initially opened in. 